### PR TITLE
chore: init code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# These owners will be the default owners for everything in the repo.
+*       @TriageCapacityPlanning/ui


### PR DESCRIPTION
Create code owners file to require PR reviews from certain members.

The team @TriageCapacityPlanning/ui is sepcified to allow PR requiring approvals from code owners.